### PR TITLE
Fix setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,10 @@ install-*/
 # Compiled Python
 *.pyc
 
+# Python packaging
+dist/
+vizaly_pat_*.egg-info
+
 # Executables
 *.exe
 *.out

--- a/Analysis/setup.py
+++ b/Analysis/setup.py
@@ -11,7 +11,6 @@ setuptools.setup(
     description="Toolkit for running analysis at scale using Slurm",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages
     url="https://github.com/lanl/VizAly-Foresight/tree/master/Analysis/pat",
     packages=setuptools.find_packages(),
     classifiers=[


### PR DESCRIPTION
The current setup file after the refactor has an errand line. This removes it.

Otherwise the Python package does not install, and crashes upon install.